### PR TITLE
*Bug* Filter sections displaying with zero options

### DIFF
--- a/src/pages/Catalog/Filter/CheckboxFilterSection.tsx
+++ b/src/pages/Catalog/Filter/CheckboxFilterSection.tsx
@@ -19,6 +19,8 @@ export default function CheckboxFilterSection({ section, isLast, selectedOptions
         setIsOpenFilterSection(!isOpenFilterSection);
     };
 
+    if (section.options.length === 0) return null;
+
     return (
         <div className="filter-section">
             <div className="section-header" onClick={toggleFilterSection}>

--- a/src/pages/Catalog/Filter/PriceRangeFilterSection.tsx
+++ b/src/pages/Catalog/Filter/PriceRangeFilterSection.tsx
@@ -69,6 +69,8 @@ export default function PriceRangeFilterSection({ minPrice, maxPrice, fixedPrice
         maxPrice ? Number(maxPrice) : fixedMaxPrice
     ];
 
+    if (fixedPriceRange[0] === fixedPriceRange[1]) return null;
+
     return (
         <div className="filter-section">
             <div className="section-header" onClick={toggleFilterSection}>

--- a/src/pages/Catalog/Filter/index.scss
+++ b/src/pages/Catalog/Filter/index.scss
@@ -51,8 +51,22 @@
 
 .filter-content {
   flex-grow: 1;
-  overflow-y: auto;
+  overflow-y: scroll;
   padding: 24px;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: colors.$color-button;
+    border-radius: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    cursor: pointer;
+    background-color: colors.$color-button-hover;
+  }
 }
 
 .used-filters-section {

--- a/src/pages/Catalog/Filter/utils.ts
+++ b/src/pages/Catalog/Filter/utils.ts
@@ -57,8 +57,9 @@ export function productsCountsToSections(
             let options: FilterSectionData["options"] = [];
 
             if (typeof value === "object" && value !== null) {
-                options = Object.entries(value as Record<string, number>).map(
-                    ([label, count]) => ({
+                options = Object.entries(value as Record<string, number>)
+                    .filter(([, count]) => count > 0)
+                    .map(([label, count]) => ({
                         label: formatFacetLabel(key, label),
                         count,
                         value: label === "" ? "null" : lowEachFirstLetter(label),

--- a/src/pages/Catalog/ProductsList/ProductsListFilterSection.tsx
+++ b/src/pages/Catalog/ProductsList/ProductsListFilterSection.tsx
@@ -2,18 +2,18 @@ import Button from "@/components/Button.tsx";
 import FilterIcon from "@/assets/icons/filter.svg?react";
 
 type Props = {
-    dataCount: number;
+    total: number;
     loading: boolean;
     onFilterOpen: () => void;
 };
 
-export default function ProductsListFilterSection({ dataCount, onFilterOpen }: Props) {
-    const dataCountText = `${dataCount} ${dataCount === 1 ? "item has" : "items have"} been found`;
+export default function ProductsListFilterSection({ total, onFilterOpen }: Props) {
+    const totalText = `${total} ${total === 1 ? "item has" : "items have"} been found`;
 
     return (
         <div className="catalog-filter-section">
             <span className="catalog-products-count">
-                {dataCountText}
+                {totalText}
             </span>
 
             <span className="catalog-filter-interactive">

--- a/src/pages/Catalog/ProductsList/index.tsx
+++ b/src/pages/Catalog/ProductsList/index.tsx
@@ -27,13 +27,14 @@ export default function CatalogProductsList({ data, loading, changePage, current
 
     return (
         <>
-            <ProductsListFilterSection dataCount={total} loading={loading} onFilterOpen={onFilterOpen}/>
             { products.length === 0
                 ? <p className="error">No products found</p>
                 : <>
-                    <div className="catalog-products-wrapper">{products.map((product) => (
-                             <CatalogProductCard product={product} key={product._id} />
-                    ))}
+                    <ProductsListFilterSection total={total} loading={loading} onFilterOpen={onFilterOpen}/>
+                    <div className="catalog-products-wrapper">
+                        {products.map((product) => (
+                            <CatalogProductCard product={product} key={product._id} />
+                        ))}
                     </div>
                     { pages > 1 &&
                         <CatalogPagination


### PR DESCRIPTION
Bug:
<img width="441" height="1074" alt="image" src="https://github.com/user-attachments/assets/6c355e02-7313-4799-9978-ac367765b019" />

The problem with the scrollbar losing its styles and getting bigger when you hover any part of the screen except the filter section has also been fixed.