### PR TITLE
Best Sellers link implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import { checkAuth } from "./store/thunks/userThunk.ts";
 import type { AppDispatch } from "./store";
 
 import Home from "./pages/Home";
-import BestSellers from "./pages/BestSellers";
 import Gifts from "./pages/Gifts";
 import Community from "./pages/Community";
 import Company from "./pages/Company";
@@ -38,7 +37,6 @@ const router = createBrowserRouter([
     errorElement: <div>Something went wrong!</div>,
     children: [
       { index: true, element: <Home /> },
-      { path: "best-sellers", element: <BestSellers /> },
       { path: "gifts", element: <Gifts /> },
       { path: "community", element: <Community /> },
       { path: "company", element: <Company /> },

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -35,7 +35,7 @@ const Layout = () => {
                         </div>
 
                         <nav className={styles['nav-links']}>
-                            <NavLink className="h3" to="/best-sellers">Best sellers</NavLink>
+                            <NavLink className="h3" to="/catalog?action=best+seller">Best sellers</NavLink>
                             <NavLink className="h3" to="/gifts">Gifts</NavLink>
                             <NavLink className="h3" to="/community">Community</NavLink>
                             <NavLink className="h3" to="/company">Company</NavLink>

--- a/src/pages/BestSellers/index.tsx
+++ b/src/pages/BestSellers/index.tsx
@@ -1,3 +1,0 @@
-export default function BestSellers() {
-  return <div>Best Sellers Page</div>;
-}


### PR DESCRIPTION
If you try to choose the "Best Sellers" section in the header, you will be redirected to the Catalog page with products that have a promotion "Best Seller".

Here is a little bug with catalog products loading, which is fixed in the [PR #40](https://github.com/vladsandbox/frontend_sparklory/pull/40/files#diff-20798acc678be98847a491916cccd7296ac4c0ac350a5f9f70915c36f16b9641)

<img width="702" height="100" alt="image" src="https://github.com/user-attachments/assets/016451c3-c98f-4d7b-9bab-4bad855427a5" />
